### PR TITLE
Updated API Reference documentation for ui-sref directive

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -93,7 +93,7 @@ function defaultOpts(el, $state) {
  *
  * Then the compiled html would be (assuming Html5Mode is off and current state is contacts):
  * <pre>
- * <a href="#/home" ui-sref="home">Home</a> | <a href="#/about" ui-sref="about">About</a> | <a href="#/contacts?page=2" ui-sref="{page: 2}">Next page</a>
+ * <a href="#/home" ui-sref="home">Home</a> | <a href="#/about" ui-sref="about">About</a> | <a href="#/contacts?page=2" ui-sref="contacts.detail({page: 2})">Next page</a>
  *
  * <ul>
  *     <li ng-repeat="contact in contacts">


### PR DESCRIPTION
ui-sref is assigned to the state incorrectly, only parameter object is passed. Corrected by assigning the contacts.detail state with the required parameter.